### PR TITLE
feat(errors): Add error handling and RecvError types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,17 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
 
+      - name: Cache cargo-expand
+        id: cache-cargo-expand
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/cargo-expand
+          key: ${{ runner.os }}-cargo-expand
+
+      - name: Install cargo-expand
+        if: steps.cache-cargo-expand.outputs.cache-hit != 'true'
+        run: cargo install cargo-expand
+
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ repository = "https://github.com/H1ghBre4k3r/notizia"
 
 [workspace.dependencies]
 notizia_gen = { version = "0.2.0", path = "notizia_gen" }
+thiserror = "2.0.18"
 tokio = { version = "1.49.0", features = ["full"] }

--- a/notizia/Cargo.toml
+++ b/notizia/Cargo.toml
@@ -11,3 +11,4 @@ repository.workspace = true
 [dependencies]
 notizia_gen.workspace = true
 tokio.workspace = true
+thiserror.workspace = true

--- a/notizia/examples/ping_pong.rs
+++ b/notizia/examples/ping_pong.rs
@@ -14,7 +14,7 @@ impl Runnable<PingMsg> for PingProc {
         for i in 0..10 {
             send!(pong_proc, PongMsg(self.this())).expect("Sending should work");
 
-            let msg = recv!(self);
+            let msg = recv!(self).unwrap();
             println!("PingProc received: {msg:?} #{i}");
         }
         pong_proc.kill();
@@ -31,7 +31,7 @@ impl Runnable<PongMsg> for PongProc {
     async fn start(&self) {
         println!("Starting PongProc");
         loop {
-            let msg = recv!(self);
+            let msg = recv!(self).unwrap();
             println!("PongProc received {msg:?}");
             let PongMsg(other) = msg;
             send!(other, PingMsg).expect("Sending should work");

--- a/notizia/src/core/errors.rs
+++ b/notizia/src/core/errors.rs
@@ -1,0 +1,48 @@
+pub use tokio::sync::mpsc::error::SendError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RecvError {
+    #[error("channel closed")]
+    Closed,
+    #[error("channel poisoned")]
+    Poisoned,
+    #[error("receive timeout")]
+    Timeout,
+}
+
+pub type RecvResult<T> = Result<T, RecvError>;
+
+pub type SendResult<T> = Result<(), SendError<T>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recv_error_implements_std_error() {
+        fn assert_is_error<E: std::error::Error + 'static>() {}
+        assert_is_error::<RecvError>();
+    }
+
+    #[test]
+    fn send_error_implements_std_error() {
+        fn assert_is_error<E: std::error::Error + 'static>() {}
+        assert_is_error::<SendError<i32>>();
+    }
+
+    #[test]
+    fn error_display_messages_are_user_friendly() {
+        assert_eq!(format!("{}", RecvError::Closed), "channel closed");
+        assert_eq!(format!("{}", RecvError::Poisoned), "channel poisoned");
+        assert_eq!(format!("{}", RecvError::Timeout), "receive timeout");
+
+        assert_eq!(format!("{}", SendError(42)), "channel closed");
+    }
+
+    #[test]
+    fn recv_error_debug_formatting() {
+        assert_eq!(format!("{:?}", RecvError::Closed), "Closed");
+        assert_eq!(format!("{:?}", RecvError::Poisoned), "Poisoned");
+        assert_eq!(format!("{:?}", RecvError::Timeout), "Timeout");
+    }
+}

--- a/notizia/src/core/mod.rs
+++ b/notizia/src/core/mod.rs
@@ -1,0 +1,1 @@
+pub mod errors;

--- a/notizia/tests/error_handling.rs
+++ b/notizia/tests/error_handling.rs
@@ -1,0 +1,124 @@
+use notizia::{
+    Runnable, Task,
+    core::errors::{RecvError, SendError},
+    spawn,
+};
+
+#[Task(TestMsg)]
+struct TestTask;
+
+#[derive(Debug, Clone)]
+enum TestMsg {
+    Ping,
+    Stop,
+}
+
+impl Runnable<TestMsg> for TestTask {
+    async fn start(&self) {
+        while let Ok(msg) = self.recv().await {
+            match msg {
+                TestMsg::Ping => {}
+                TestMsg::Stop => break,
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn recv_returns_closed_error_when_channel_closed() {
+    let mailbox = notizia::Mailbox::<TestMsg>::new();
+
+    // Create a channel directly
+    let (sender, receiver) = notizia::tokio::sync::mpsc::unbounded_channel();
+
+    // Set the receiver
+    mailbox.set_receiver(receiver).await;
+
+    // Drop the sender to close the channel
+    drop(sender);
+
+    // This should return RecvError::Closed when we try to recv
+    let result = mailbox.recv().await;
+    assert!(matches!(result, Err(RecvError::Closed)));
+}
+
+#[tokio::test]
+async fn send_returns_disconnected_when_receiver_dropped() {
+    // Create a channel directly
+    let (sender, receiver) = notizia::tokio::sync::mpsc::unbounded_channel();
+
+    // Drop the receiver immediately
+    drop(receiver);
+
+    // Try to send a message - should fail
+    let result = sender.send(TestMsg::Ping);
+
+    assert!(matches!(result, Err(SendError(_))));
+}
+
+#[tokio::test]
+async fn error_types_can_be_propagated_with_question_mark() {
+    async fn try_send(handle: &notizia::TaskHandle<TestMsg>) -> Result<(), SendError<TestMsg>> {
+        handle.send(TestMsg::Ping)?;
+        Ok(())
+    }
+
+    let task = TestTask;
+    let handle = spawn!(task);
+
+    // Test that we can propagate errors with ?
+    let result = try_send(&handle).await;
+    assert!(result.is_ok());
+
+    // Kill the task
+    handle.kill();
+}
+
+#[tokio::test]
+async fn recv_returns_poisoned_error_when_receiver_not_set() {
+    let mailbox = notizia::Mailbox::<TestMsg>::new();
+
+    // Try to receive without setting the receiver
+    let result = mailbox.recv().await;
+    assert!(matches!(result, Err(RecvError::Poisoned)));
+}
+
+#[tokio::test]
+async fn mailbox_can_reuse_receiver_after_close() {
+    let task = TestTask;
+    let handle = spawn!(task);
+
+    // Send a message successfully
+    assert!(handle.send(TestMsg::Stop).is_ok());
+
+    // Let the task process the message
+    tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+    // After the task completes, sends should fail
+    let result = handle.send(TestMsg::Ping);
+    assert!(matches!(result, Err(SendError(_))));
+}
+
+#[tokio::test]
+async fn send_error_returns_original_message() {
+    // Create a channel directly
+    let (sender, receiver) = notizia::tokio::sync::mpsc::unbounded_channel();
+
+    // Drop the receiver immediately
+    drop(receiver);
+
+    // Try to send a message
+    let original_msg = TestMsg::Ping;
+    let result = sender.send(original_msg.clone());
+
+    // Verify the error contains the original message
+    assert!(matches!(result, Err(SendError(_))));
+
+    // We can extract the message from the error
+    if let Err(SendError(msg)) = result {
+        match msg {
+            TestMsg::Ping => {}
+            TestMsg::Stop => panic!("Wrong message returned"),
+        }
+    }
+}

--- a/notizia_gen/Cargo.toml
+++ b/notizia_gen/Cargo.toml
@@ -13,3 +13,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0.43"
 syn = { version = "2.0.114", features = ["full"] }
+
+[dev-dependencies]
+macrotest = "1.2"
+trybuild = "1.0.114"

--- a/notizia_gen/tests/compile_fail.rs
+++ b/notizia_gen/tests/compile_fail.rs
@@ -1,0 +1,7 @@
+/// Compile-fail tests for the #[Task] macro
+/// These tests verify that the macro correctly rejects invalid code
+#[test]
+fn compile_fail_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_fail/*.rs");
+}

--- a/notizia_gen/tests/compile_fail/invalid_task_syntax.rs
+++ b/notizia_gen/tests/compile_fail/invalid_task_syntax.rs
@@ -1,0 +1,10 @@
+use notizia_gen::Task;
+
+#[derive(Clone, Debug)]
+struct Message;
+
+// Missing the message type parameter - should fail
+#[Task]
+struct MyTask;
+
+fn main() {}

--- a/notizia_gen/tests/compile_fail/invalid_task_syntax.stderr
+++ b/notizia_gen/tests/compile_fail/invalid_task_syntax.stderr
@@ -1,0 +1,7 @@
+error: unexpected end of input, expected identifier
+ --> tests/compile_fail/invalid_task_syntax.rs:7:1
+  |
+7 | #[Task]
+  | ^^^^^^^
+  |
+  = note: this error originates in the attribute macro `Task` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/notizia_gen/tests/compile_fail/non_clone_message.rs
+++ b/notizia_gen/tests/compile_fail/non_clone_message.rs
@@ -1,0 +1,12 @@
+use notizia_gen::Task;
+
+/// This should fail because the message type doesn't implement Clone
+#[derive(Debug)]
+struct NonCloneMessage {
+    data: String,
+}
+
+#[Task(NonCloneMessage)]
+struct MyTask;
+
+fn main() {}

--- a/notizia_gen/tests/compile_fail/non_clone_message.stderr
+++ b/notizia_gen/tests/compile_fail/non_clone_message.stderr
@@ -1,0 +1,24 @@
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `tokio`
+ --> tests/compile_fail/non_clone_message.rs:9:1
+  |
+9 | #[Task(NonCloneMessage)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `tokio`
+  |
+  = note: this error originates in the attribute macro `Task` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `notizia`
+ --> tests/compile_fail/non_clone_message.rs:9:1
+  |
+9 | #[Task(NonCloneMessage)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `notizia`
+  |
+  = help: if you wanted to use a crate named `notizia`, use `cargo add notizia` to add it to your `Cargo.toml`
+  = note: this error originates in the attribute macro `Task` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0425]: cannot find value `MyTaskState` in module `__MyTask_gen`
+ --> tests/compile_fail/non_clone_message.rs:9:1
+  |
+9 | #[Task(NonCloneMessage)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^ not found in `__MyTask_gen`
+  |
+  = note: this error originates in the attribute macro `Task` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/notizia_gen/tests/expand/basic_task.expanded.rs
+++ b/notizia_gen/tests/expand/basic_task.expanded.rs
@@ -1,0 +1,57 @@
+use notizia_gen::Task;
+struct PingMessage;
+#[automatically_derived]
+impl ::core::clone::Clone for PingMessage {
+    #[inline]
+    fn clone(&self) -> PingMessage {
+        PingMessage
+    }
+}
+#[automatically_derived]
+impl ::core::fmt::Debug for PingMessage {
+    #[inline]
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Formatter::write_str(f, "PingMessage")
+    }
+}
+struct PingTask;
+impl notizia::Task<PingMessage> for PingTask {
+    fn __setup(
+        &self,
+        receiver: notizia::tokio::sync::mpsc::UnboundedReceiver<PingMessage>,
+    ) -> impl std::future::Future<Output = ()> + Send {
+        async move {
+            let mb = self.mailbox();
+            mb.set_receiver(receiver).await;
+            self.start().await
+        }
+    }
+    fn mailbox(&self) -> notizia::Mailbox<PingMessage> {
+        __PingTask_gen::PingTaskState.get().mailbox
+    }
+    fn run(self) -> notizia::TaskHandle<PingMessage> {
+        let (sender, receiver) = notizia::tokio::sync::mpsc::unbounded_channel::<
+            PingMessage,
+        >();
+        let task = __PingTask_gen::PingTaskState
+            .scope(
+                notizia::TaskState {
+                    mailbox: notizia::Mailbox::new(),
+                    sender: sender.clone(),
+                },
+                async move {
+                    let handle = self.__setup(receiver);
+                    handle.await
+                },
+            );
+        let handle = notizia::tokio::spawn(task);
+        notizia::TaskHandle::new(sender, handle)
+    }
+    fn this(&self) -> notizia::TaskRef<PingMessage> {
+        notizia::TaskRef::new(__PingTask_gen::PingTaskState.get().sender)
+    }
+}
+mod __PingTask_gen {
+    use super::*;
+}
+fn main() {}

--- a/notizia_gen/tests/expand/basic_task.rs
+++ b/notizia_gen/tests/expand/basic_task.rs
@@ -1,0 +1,9 @@
+use notizia_gen::Task;
+
+#[derive(Clone, Debug)]
+struct PingMessage;
+
+#[Task(PingMessage)]
+struct PingTask;
+
+fn main() {}

--- a/notizia_gen/tests/expansion_tests.rs
+++ b/notizia_gen/tests/expansion_tests.rs
@@ -1,0 +1,6 @@
+/// Macro expansion snapshot tests using macrotest
+/// These tests verify that the #[Task] macro expands to the correct code
+#[test]
+fn expansion_tests() {
+    macrotest::expand("tests/expand/*.rs");
+}


### PR DESCRIPTION
Implement core error types for message passing, including RecvError with Closed, Poisoned, and Timeout variants. Add SendResult and RecvResult type aliases. Update examples and tests to use new error handling mechanisms.

Closes #3 