### PR TITLE
feat(ci): Add code coverage tracking and reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,42 @@
+# Codecov Configuration for Notizia
+# https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 1%
+        if_ci_failed: error
+
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+        if_ci_failed: error
+
+  range: 70..100
+
+comment:
+  layout: "header, diff, changes, uncovered, files, footer"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+
+ignore:
+  - "target/"
+  - "**/tests.rs"
+  - "tests/"
+  - "benches/"
+  - "**/tests/**/*.expanded.rs"
+  - "notizia_gen/tests/expand/*.expanded.rs"
+
+flags:
+  notizia:
+    paths:
+      - notizia/src/
+    
+  notizia_gen:
+    paths:
+      - notizia_gen/src/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,3 +173,69 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --all -- --check
+
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo-expand
+        id: cache-cargo-expand
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/cargo-expand
+          key: ${{ runner.os }}-cargo-expand
+
+      - name: Install cargo-expand
+        if: steps.cache-cargo-expand.outputs.cache-hit != 'true'
+        run: cargo install cargo-expand
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/registry/index
+          key: ubuntu-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ubuntu-cargo-registry-
+
+      - name: Cache cargo build
+        uses: actions/cache@v5
+        with:
+          path: target
+          key: ubuntu-stable-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ubuntu-stable-coverage-
+            ubuntu-stable-
+
+      - name: Generate coverage (LCOV)
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+
+      - name: Generate coverage (HTML)
+        run: cargo llvm-cov --workspace --html
+
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-report
+          path: target/llvm-cov/html/
+          retention-days: 7
+
+      - name: Check coverage threshold (90% - non-blocking)
+        continue-on-error: true
+        run: |
+          echo "Checking coverage threshold (90%)..."
+          cargo llvm-cov --workspace --fail-under-lines 90 || echo "⚠️  Coverage is below 90% threshold, but this is non-blocking for now."

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ Cargo.lock
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Coverage reports
+lcov.info
+*.profraw
+*.profdata

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,96 @@
+# Notizia Development Makefile
+# 
+# This Makefile provides convenient targets for common development tasks,
+# particularly around testing and code coverage.
+
+.PHONY: help test coverage coverage-check coverage-lcov test-coverage clean-coverage install-tools
+
+# Default target - show help
+help:
+	@echo "Notizia Development Commands"
+	@echo ""
+	@echo "Testing:"
+	@echo "  make test              - Run all tests in the workspace"
+	@echo "  make test-lib          - Run only library unit tests"
+	@echo "  make test-integration  - Run only integration tests"
+	@echo "  make test-doc          - Run only documentation tests"
+	@echo ""
+	@echo "Coverage:"
+	@echo "  make coverage          - Generate HTML coverage report and open in browser"
+	@echo "  make coverage-check    - Check if coverage meets 90% threshold"
+	@echo "  make coverage-lcov     - Generate LCOV format coverage report"
+	@echo "  make test-coverage     - Run tests with coverage tracking (terminal output)"
+	@echo "  make clean-coverage    - Remove all coverage artifacts"
+	@echo ""
+	@echo "Development:"
+	@echo "  make install-tools     - Install required development tools"
+	@echo "  make fmt               - Format code with rustfmt"
+	@echo "  make clippy            - Run clippy lints"
+	@echo "  make build             - Build the workspace"
+	@echo "  make clean             - Clean build artifacts"
+
+# Testing targets
+test:
+	cargo test --workspace --verbose
+
+test-lib:
+	cargo test --workspace --lib
+
+test-integration:
+	cargo test --workspace --tests
+
+test-doc:
+	cargo test --workspace --doc
+
+# Coverage targets
+coverage:
+	@echo "Generating HTML coverage report..."
+	cargo llvm-cov --workspace --html
+	@echo "Opening coverage report in browser..."
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		open target/llvm-cov/html/index.html; \
+	elif [ "$$(uname)" = "Linux" ]; then \
+		xdg-open target/llvm-cov/html/index.html 2>/dev/null || echo "Please open target/llvm-cov/html/index.html in your browser"; \
+	else \
+		echo "Please open target/llvm-cov/html/index.html in your browser"; \
+	fi
+
+coverage-check:
+	@echo "Checking coverage threshold (90%)..."
+	@cargo llvm-cov --workspace --fail-under-lines 90 && \
+		echo "✓ Coverage meets 90% threshold!" || \
+		(echo "⚠️  Coverage is below 90% threshold" && exit 1)
+
+coverage-lcov:
+	@echo "Generating LCOV coverage report..."
+	cargo llvm-cov --workspace --lcov --output-path lcov.info
+	@echo "Coverage report generated: lcov.info"
+
+test-coverage:
+	@echo "Running tests with coverage..."
+	cargo llvm-cov --workspace
+
+clean-coverage:
+	@echo "Cleaning coverage artifacts..."
+	rm -rf target/llvm-cov/
+	rm -f lcov.info
+	@echo "Coverage artifacts removed"
+
+# Development targets
+install-tools:
+	@echo "Installing development tools..."
+	cargo install cargo-llvm-cov
+	cargo install cargo-watch
+	@echo "Tools installed successfully"
+
+fmt:
+	cargo fmt --all
+
+clippy:
+	cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+build:
+	cargo build --workspace --verbose
+
+clean:
+	cargo clean

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Notizia
 
+[![codecov](https://codecov.io/gh/H1ghBre4k3r/notizia/branch/main/graph/badge.svg)](https://codecov.io/gh/H1ghBre4k3r/notizia)
+[![CI](https://github.com/H1ghBre4k3r/notizia/workflows/CI/badge.svg)](https://github.com/H1ghBre4k3r/notizia/actions)
+
 **Frictionless message passing for the Tokio runtime.**
 
 Async Rust is powerful, but managing channels, task handles, and state synchronization often leads to verbose boilerplate. Notizia cuts through the noise. It provides a thin, type-safe layer over Tokio's primitives, offering an actor-like model that feels native to Rust.
@@ -74,3 +77,39 @@ Add this to your `Cargo.toml`:
 [dependencies]
 notizia = "0.1"
 ```
+
+## Development
+
+### Running Tests
+
+```bash
+# Run all tests
+cargo test --workspace
+
+# Run tests with coverage
+make test-coverage
+
+# Generate HTML coverage report
+make coverage
+```
+
+### Code Coverage
+
+This project uses `cargo-llvm-cov` for code coverage tracking with a target of 90% coverage. Coverage reports are automatically generated in CI and uploaded to [Codecov](https://codecov.io/gh/H1ghBre4k3r/notizia).
+
+**Local Coverage Reports:**
+
+First, install the coverage tool (one-time setup):
+```bash
+make install-tools
+# or manually: cargo install cargo-llvm-cov
+```
+
+Then generate coverage reports:
+```bash
+make coverage          # Generate HTML report and open in browser
+make coverage-check    # Check if coverage meets 90% threshold
+make coverage-lcov     # Generate LCOV format for tooling
+```
+
+Coverage reports are stored in `target/llvm-cov/html/` and can also be downloaded from CI artifacts on each pull request.


### PR DESCRIPTION
Implement comprehensive code coverage infrastructure for Notizia project. 
Add Codecov configuration, GitHub Actions workflow for coverage 
generation, and update README with coverage instructions. Introduce 
Makefile targets for local coverage generation and reporting.

Key changes:
- Configure Codecov with 90% coverage target
- Add GitHub Actions coverage job
- Create Makefile for coverage-related tasks
- Update README with coverage documentation
- Add .gitignore entries for coverage artifacts